### PR TITLE
Add configs for different PVP scenarios; improve detection methods

### DIFF
--- a/src/main/java/DeathDotter/DeathDotterConfig.java
+++ b/src/main/java/DeathDotter/DeathDotterConfig.java
@@ -3,19 +3,43 @@ package DeathDotter;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
+import net.runelite.client.config.ConfigSection;
 
 @ConfigGroup(DeathDotterConfig.GROUP)
-public interface DeathDotterConfig extends Config
-{
+public interface DeathDotterConfig extends Config {
 
-    String GROUP = "DeathDotter";
-    @ConfigItem(
-            keyName = "disableOutsidePvp",
-            name = "Disable Outside PvP Zones",
-            description = "Automatically disable the plugin outside PvP zones (Wilderness or PvP world)"
-    )
-    default boolean disableOutsidePvp()
-    {
-        return false; // Default to disabling the plugin outside PvP zones
-    }
+  String GROUP = "DeathDotter";
+
+  @ConfigSection(name = "Active Areas", description = "Configure which areas the plugin should be active in", position = 1)
+  String activeAreasSection = "activeAreas";
+
+  @ConfigItem(keyName = "alwaysActive", name = "Always Active", description = "Keep the plugin active in all areas (overrides other settings)", section = activeAreasSection, position = 0)
+  default boolean alwaysActive() {
+    return false;
+  }
+
+  @ConfigItem(keyName = "activeInWilderness", name = "Active in Wilderness", description = "Enable the plugin in the Wilderness", section = activeAreasSection, position = 1)
+  default boolean activeInWilderness() {
+    return true;
+  }
+
+  @ConfigItem(keyName = "activeInPvpWorlds", name = "Active in PvP Worlds", description = "Enable the plugin in PvP worlds", section = activeAreasSection, position = 2)
+  default boolean activeInPvpWorlds() {
+    return true;
+  }
+
+  @ConfigItem(keyName = "activeInEmirsArena", name = "Active in Emir's Arena", description = "Enable the plugin in Emir's Arena (PVP Arena)", section = activeAreasSection, position = 3)
+  default boolean activeInPvpArena() {
+    return true;
+  }
+
+  @ConfigItem(keyName = "activeInLms", name = "Active in LMS", description = "Enable the plugin in Last Man Standing", section = activeAreasSection, position = 4)
+  default boolean activeInLms() {
+    return true;
+  }
+
+  @ConfigItem(keyName = "activeInDeadman", name = "Active in Deadman", description = "Enable the plugin in Deadman mode", section = activeAreasSection, position = 5)
+  default boolean activeInDeadman() {
+    return true;
+  }
 }

--- a/src/main/java/DeathDotter/DeathDotterPlugin.java
+++ b/src/main/java/DeathDotter/DeathDotterPlugin.java
@@ -1,6 +1,9 @@
 package DeathDotter;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import java.util.Set;
+import java.util.List;
 import javax.inject.Inject;
 import com.google.inject.Provides;
 import net.runelite.api.Client;
@@ -8,156 +11,193 @@ import net.runelite.api.Player;
 import net.runelite.api.Renderable;
 import net.runelite.api.WorldType;
 import net.runelite.api.coords.LocalPoint;
-import net.runelite.api.coords.WorldPoint;
 import net.runelite.client.callback.Hooks;
 import net.runelite.client.config.ConfigManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
-import java.util.List;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.api.gameval.VarbitID;
 
+@PluginDescriptor(name = "Death Dotter", description = "Allows you to switch rendered entities when players occupy the same tiles", tags = {
+    "pvp", "player", "player vs player", "death dotter", "death dot", "death dotting",
+    "entity", "entity hider", "wilderness", "emir's", "emir's arena", "pvp arena", "pvp world" })
 
-@PluginDescriptor
-(
-        name = "Death Dotter",
-        description = "Allows you to switch rendered entities when players occupy the same tiles",
-        tags = {"pvp", "player", "player vs player", "death dotter", "death dot", "death dotting",
-                "entity", "entity hider", "wilderness", "emir's", "emir's arena", "pvp arena", "pvp world"}
-)
+public class DeathDotterPlugin extends Plugin {
 
-public class DeathDotterPlugin extends Plugin 
-{
-    @Inject
-    private Client client;
+  private static final Set<Integer> LMS_REGIONS = ImmutableSet.of(12344, 12600, 13658, 13659, 13660, 13914, 13915,
+      13916, 13918,
+      13919, 13920,
+      14174, 14175,
+      14176, 14430,
+      14431, 14432);
 
-    @Inject
-    private Hooks hooks;
+  @Inject
+  private Client client;
 
-    @Inject
-    private DeathDotterConfig config;
+  @Inject
+  private Hooks hooks;
 
-    private final Hooks.RenderableDrawListener drawListener = this::shouldDraw;
+  @Inject
+  private DeathDotterConfig config;
 
-    private boolean disableWhileInPvpZone;
+  private boolean activeInWilderness;
+  private boolean activeInPvpWorlds;
+  private boolean activeInPvpArena;
+  private boolean activeInLms;
+  private boolean activeInDeadman;
+  private boolean alwaysActive;
 
-    @Provides
-    DeathDotterConfig provideConfig(ConfigManager configManager)
-    {
-        return configManager.getConfig(DeathDotterConfig.class);
+  private final Hooks.RenderableDrawListener drawListener = this::shouldDraw;
+
+  @Provides
+  DeathDotterConfig provideConfig(ConfigManager configManager) {
+    return configManager.getConfig(DeathDotterConfig.class);
+  }
+
+  @Override
+  protected void startUp() {
+    updateConfig();
+    hooks.registerRenderableDrawListener(drawListener);
+  }
+
+  @Override
+  protected void shutDown() {
+    hooks.unregisterRenderableDrawListener(drawListener);
+  }
+
+  @Subscribe
+  public void onConfigChanged(ConfigChanged e) {
+    if (e.getGroup().equals(DeathDotterConfig.GROUP)) {
+      updateConfig();
+    }
+  }
+
+  private void updateConfig() {
+    alwaysActive = config.alwaysActive();
+    activeInWilderness = config.activeInWilderness();
+    activeInPvpWorlds = config.activeInPvpWorlds();
+    activeInPvpArena = config.activeInPvpArena();
+    activeInLms = config.activeInLms();
+    activeInDeadman = config.activeInDeadman();
+  }
+
+  /**
+   * Determines if the plugin should be active based on the current location and
+   * configuration.
+   *
+   * @return true if the plugin should be active, false otherwise
+   */
+  private boolean shouldPluginBeActive() {
+    // If always active is enabled, plugin works everywhere
+    if (alwaysActive) {
+      return true;
     }
 
-    @Override
-    protected void startUp()
-    {
-        updateConfig();
-        hooks.registerRenderableDrawListener(drawListener);
+    // Check if we're in any of the configured active areas
+    if (activeInWilderness && isInWilderness()) {
+      return true;
     }
 
-    @Override
-    protected void shutDown()
-    {
-        hooks.unregisterRenderableDrawListener(drawListener);
+    if (activeInPvpWorlds && isPvpWorld()) {
+      return true;
     }
 
-    @Subscribe
-    public void onConfigChanged(ConfigChanged e)
-    {
-        if (e.getGroup().equals(DeathDotterConfig.GROUP))
-        {
-            updateConfig();
-        }
+    if (activeInPvpArena && isPvpArena()) {
+      return true;
     }
 
-
-    private void updateConfig()
-    {
-        disableWhileInPvpZone = config.disableOutsidePvp();
+    if (activeInLms && isLms()) {
+      return true;
     }
 
-    private boolean isInPvpZone()
-    {
-
-        // Check if the current world is a PvP world
-        boolean isPvpWorld = client.getWorldType().contains(WorldType.PVP);
-        boolean isArenaWorld = client.getWorldType().contains(WorldType.PVP_ARENA);
-
-        // Check if the player is in the Wilderness
-        WorldPoint playerLocation = client.getLocalPlayer().getWorldLocation();
-        boolean isInWilderness = isInWilderness();
-
-
-        // Return true if player is in PvP zone
-        return isPvpWorld || isInWilderness || isArenaWorld;
+    if (activeInDeadman && isDeadman()) {
+      return true;
     }
 
-    private boolean isInWilderness()
-    {
-        if (!client.isClientThread())
-        {
-            return false; // Assume not in Wilderness if not on the client thread
-        }
-        return client.getVarbitValue(VarbitID.INSIDE_WILDERNESS) == 1;
-    }
+    return false;
+  }
 
-    private boolean areModelsOverlapping(Player localPlayer, Player otherPlayer) 
-    {
-        if (localPlayer == otherPlayer)
-        {
-            return false;
-        }
-        LocalPoint localLoc1 = localPlayer.getLocalLocation();
-        LocalPoint localLoc2 = otherPlayer.getLocalLocation();
+  private boolean isPvpWorld() {
+    return client.getWorldType().contains(WorldType.PVP);
+  }
 
-        // Calculate squared distance between the two players
-        int dx = localLoc1.getX() - localLoc2.getX();
-        int dy = localLoc1.getY() - localLoc2.getY();
+  private boolean isPvpArena() {
+    return client.getWorldType().contains(WorldType.PVP_ARENA);
+  }
 
-        int distanceSquared = dx * dx + dy * dy;
+  private boolean isLms() {
+    final int[] mapRegions = client.getMapRegions();
 
-        // Get radii and calculate radius sum
-        int localRadius = 1;
-        int otherRadius = 1;
-        int radiusSum = localRadius + otherRadius;
-
-        // Check for overlap
-        return distanceSquared <= radiusSum;
-    }
-
-    @VisibleForTesting
-    boolean shouldDraw(Renderable renderable, boolean drawingUi)
-    {
-
-        if (config.disableOutsidePvp() && !isInPvpZone())
-        {
-            return true; // Always draw everything if outside PvP zones
-        }
-
-        // this should only be run on the client thread
-        if (!client.isClientThread())
-        {
-            return true;
-        }
-
-        if (renderable instanceof Player) 
-        {
-            Player local = client.getLocalPlayer();
-
-            // Check if the renderable is the local player
-            if (renderable == local) 
-            {
-                List<Player> players = client.getPlayers();
-
-                for (Player otherPlayer : players) {
-
-                    if (areModelsOverlapping(local, otherPlayer)) 
-                    {
-                        return false; // Hide local player
-                    }
-                }
-            }
-        }
+    for (int region : mapRegions) {
+      if (LMS_REGIONS.contains(region)) {
         return true;
+      }
     }
+
+    return false;
+  }
+
+  private boolean isDeadman() {
+    return client.getWorldType().contains(WorldType.DEADMAN);
+  }
+
+  private boolean isInWilderness() {
+    if (!client.isClientThread()) {
+      return false; // Assume not in Wilderness if not on the client thread
+    }
+    return client.getVarbitValue(VarbitID.INSIDE_WILDERNESS) == 1;
+  }
+
+  private boolean areModelsOverlapping(Player localPlayer, Player otherPlayer) {
+    if (localPlayer == otherPlayer) {
+      return false;
+    }
+
+    LocalPoint localLoc1 = localPlayer.getLocalLocation();
+    LocalPoint localLoc2 = otherPlayer.getLocalLocation();
+
+    // Calculate squared distance between the two players
+    int dx = localLoc1.getX() - localLoc2.getX();
+    int dy = localLoc1.getY() - localLoc2.getY();
+
+    int distanceSquared = dx * dx + dy * dy;
+
+    // Get radii and calculate radius sum
+    int localRadius = 1;
+    int otherRadius = 1;
+    int radiusSum = localRadius + otherRadius;
+
+    // Check for overlap
+    return distanceSquared <= radiusSum;
+  }
+
+  @VisibleForTesting
+  boolean shouldDraw(Renderable renderable, boolean drawingUi) {
+    // Draw everything when plugin shouldn't be active
+    if (!shouldPluginBeActive()) {
+      return true;
+    }
+
+    // this should only be run on the client thread
+    if (!client.isClientThread()) {
+      return true;
+    }
+
+    if (renderable instanceof Player) {
+      Player local = client.getLocalPlayer();
+
+      // Check if the renderable is the local player
+      if (renderable == local) {
+        List<Player> players = client.getPlayers();
+
+        for (Player otherPlayer : players) {
+          if (areModelsOverlapping(local, otherPlayer)) {
+            return false; // Hide local player
+          }
+        }
+      }
+    }
+    return true;
+  }
 }


### PR DESCRIPTION
This adds separate configs for enabling the plugin in:

* The wilderness (also changes the detection method a bit, I think? I used the [IN_WILDERNESS Varbit](https://oldschool.runescape.wiki/w/RuneScape:Varbit/5963) at least which is pretty fast/simple.)
* PVP worlds
* PVP arena worlds/Emir's Arena
* LMS (and adds detection logic for this - #3)
* In DMM (Deadman worlds)
* Always enabled (overrides others)

This fixes the issue with the plugin not working in LMS properly and makes it more flexible. I can confirm at least that this works properly in LMS, Ferox (Wilderness), and PVP worlds.

Also - sorry, I just used RuneLite's standard formatting rules to format the code, since I had moved some stuff around and wasn't sure how it was all formatted previously, so the diff looks a bit ugly.