### PR TITLE
Add hide 2d setting (on by default)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 nbactions.xml
 nb-configuration.xml
 nbproject/
+bin/

--- a/src/main/java/DeathDotter/DeathDotterConfig.java
+++ b/src/main/java/DeathDotter/DeathDotterConfig.java
@@ -10,8 +10,16 @@ public interface DeathDotterConfig extends Config {
 
   String GROUP = "DeathDotter";
 
-  @ConfigSection(name = "Active Areas", description = "Configure which areas the plugin should be active in", position = 1)
+  @ConfigSection(name = "General Settings", description = "General settings for the plugin", position = 1)
+  String generalSettingsSection = "generalSettings";
+
+  @ConfigSection(name = "Active Areas", description = "Configure which areas the plugin should be active in", position = 2)
   String activeAreasSection = "activeAreas";
+
+  @ConfigItem(keyName = "hide2D", name = "Hide 2D", description = "Hide the 2D elements of your player (e.g. health bar, prayers)", section = activeAreasSection, position = 1)
+  default boolean hide2D() {
+    return true;
+  }
 
   @ConfigItem(keyName = "alwaysActive", name = "Always Active", description = "Keep the plugin active in all areas (overrides other settings)", section = activeAreasSection, position = 0)
   default boolean alwaysActive() {

--- a/src/main/java/DeathDotter/DeathDotterPlugin.java
+++ b/src/main/java/DeathDotter/DeathDotterPlugin.java
@@ -47,6 +47,7 @@ public class DeathDotterPlugin extends Plugin {
   private boolean activeInLms;
   private boolean activeInDeadman;
   private boolean alwaysActive;
+  private boolean hide2D;
 
   private final Hooks.RenderableDrawListener drawListener = this::shouldDraw;
 
@@ -80,6 +81,7 @@ public class DeathDotterPlugin extends Plugin {
     activeInPvpArena = config.activeInPvpArena();
     activeInLms = config.activeInLms();
     activeInDeadman = config.activeInDeadman();
+    hide2D = config.hide2D();
   }
 
   /**
@@ -193,7 +195,8 @@ public class DeathDotterPlugin extends Plugin {
 
         for (Player otherPlayer : players) {
           if (areModelsOverlapping(local, otherPlayer)) {
-            return false; // Hide local player
+            // Hide local player and hide 2D elements if hide2D is enabled
+            return !(drawingUi ? hide2D : true);
           }
         }
       }


### PR DESCRIPTION
Adds a setting to hide/show the 2d of your player.
Making sure it's on by default means the default behavior of the plugin stays the same.

Closes https://github.com/dmgear/deathdotterplugin/issues/1 and https://github.com/dmgear/deathdotterplugin/issues/2